### PR TITLE
added gen-graphql-schema command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,12 @@ import devOpsPluginCommands from "./commands/devops-plugin";
 import pluginCommands from "./commands/plugin";
 import prismaCommands from "./commands/prisma";
 import otelCommands from "./commands/otel";
+import {genGraphqlSchema} from "./utils/index";
 const fsExtras = require("fs-extra");
 import { cwd } from "process";
 import { readFileSync } from "fs";
+import { globSync } from "glob";
+import inquirer from "inquirer";
 
 // load .env
 dotenv.config({ path: path.resolve(__dirname, "../.env") });
@@ -191,6 +194,16 @@ export const isAGodspeedProject = () => {
     .action(async () => {
       if (isAGodspeedProject()) {
         spawnSync("npm", ["run", "gen-crud-api"], { stdio: "inherit" });
+      }
+    });
+    program
+    .command("gen-graphql-schema")
+    .description(
+      "scans your graphql events and generate graphql schema"
+    )
+    .action(async () => {
+      if (isAGodspeedProject()) {
+        await genGraphqlSchema()
       }
     });
   program


### PR DESCRIPTION
## Problem Description
### What we need
- We need GraphQL integration in godspeed with Auto generation and Auto generation of resolvers with events and workflows. 
- For this Auto generation of Graphql schema i added new command in cli. 
-  `gen-graphql-schema` helps to scan all graphql events, create graphql schema from event schema and create resolvers also.
### Steps to use graphql plugin in project :
- Use `godspeed plugin add` and select `graphql-as-eventsource` to install graphql plugin.
- write events with corresponding workflows of graphql eventsource.
- Use `gen-graphql-schema` to auto generate graphql schema.
- once plugin added to your project, plugin auto detects graphql schema generated by `gen-graphql-schema` command.
- use `godspeed dev` to start dev server. you can see Apollo sandbox UI in localhost:4000 by default. From there you can do queries or mutations.
### How we will approach
 - [x] go through graphql documentation and Apollo documentation. 
 - [x] setup basic graphql plugin with events and workflows.
 - [x] add event schema and framework automatically adds validation.
 - [x] generate swagger schema from graphql events
 - [x] convert swagger.json to graphql schema
 - [x] Add new command `gen-graphql-schema` in cli to automate above 2 steps.
 - [x] write readme file with detailed instructions and examples.
 
### What i tested:

- i tested ` gen-grapql-schema ` command manually. It perfectly generating schema of all graphql event sources. 

For example we have 2 graphql event sources apollo1, apollo2. 

Step 1: It asks `select your graphql events ` and provide list of event sources we have in src/eventsource folder. Assume he selected apollo1, apollo2.

step 2: This command filters all events of this event sources separately and generates 2 swagger schema files in .temp folder.

step 3: converts swagger schema to apollo1.graphql and apollo2.graphql in .src/eventsources folder.

When he start server,  plugin directly searches in 
src/eventsource folder for schema files and starts  graphql server.

While i am testing this code perfectly implemented above steps.

graphql plugin PR [https://github.com/godspeedsystems/gs-plugins/pull/76](url)


Issue link[https://github.com/godspeedsystems/gs-plugins/issues/70](url)