### PR TITLE
removed prisma plugin

### DIFF
--- a/src/commands/create/index.ts
+++ b/src/commands/create/index.ts
@@ -9,7 +9,7 @@ import path from "path"
 // } from "../../utils/dockerUtility";
 // import checkPrerequisite from "../../utils/checkPrerequisite";
 import {
-  installDependencies, prismaPlugInstall,
+  installDependencies, installPackage,
   validateAndCreateProjectDirectory,
 } from "../../utils/index";
 import { copyingLocalTemplate } from "../../utils";
@@ -79,7 +79,7 @@ export default async function create(
 
 
 
-  await prismaPlugInstall(projectDirPath)
+  await installPackage(projectDirPath,'@godspeedsystems/plugins-prisma-as-datastore')
   await installDependencies(projectDirPath, projectName);
 
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -300,9 +300,9 @@ export const installDependencies = async (
 
 };
 
-export const prismaPlugInstall = async (projectDirPath: string) => {
+export const installPackage = async (projectDirPath: string,package_name:string) => {
   async function installprisma(): Promise<void> {
-    const command = 'npm install @godspeedsystems/plugins-prisma-as-datastore';
+    const command = `npm install ${package_name}`;
 
     return new Promise<void>((resolve, reject) => {
       const child = exec(command, {


### PR DESCRIPTION
if user selects mongo-as-prisma example then `@godspeedsystems/plugins-prisma-as-datastore@latest` will add in dependencies of package.json file. while installing all dependencies  prisma plugin will also install. 
i test this manually, it's working well.