### PR TITLE
fix: specify NODE_ENV=production by default, when not specfied by user

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@godspeedsystems/godspeed",
   "description": "Godspeed CLI",
   "homepage": "https://godspeed.systems",
-  "version": "2.9.1",
+  "version": "2.9.2",
   "main": "./lib/index.js",
   "bin": {
     "godspeed": "./lib/index.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -219,8 +219,8 @@ export const isAGodspeedProject = () => {
         spawnSync("npm", ["run", "build"], {
           stdio: "inherit",
           env: {
-            ...process.env,
             NODE_ENV: "production",
+            ...process.env,
           },
         });
       }
@@ -233,8 +233,8 @@ export const isAGodspeedProject = () => {
         spawnSync("npm", ["run", "preview"], {
           stdio: "inherit",
           env: {
-            ...process.env,
             NODE_ENV: "production",
+            ...process.env,
           },
         });
       }
@@ -300,8 +300,8 @@ export const isAGodspeedProject = () => {
         spawnSync("npm", ["run", "serve"], {
           stdio: "inherit",
           env: {
-            ...process.env,
             NODE_ENV: "production",
+            ...process.env,
           },
         });
       }


### PR DESCRIPTION
Fixes #84 